### PR TITLE
fix(analyze): "である" の判定を"である"のみ限定

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/azu/analyze-desumasu-dearu/issues"
   },
   "version": "3.0.3",
-  "description": "文の敬体(ですます調)、常体(である調)を解析。",
+  "description": "文の敬体(ですます調)、常体(である調)を解析",
   "main": "lib/analyze.js",
   "files": [
     "lib",

--- a/src/analyze.js
+++ b/src/analyze.js
@@ -95,11 +95,15 @@ export function analyze(text) {
     return getTokenizer().then(tokenizer => {
         const tokens = _tokensCacheMap[text] ? _tokensCacheMap[text] : tokenizer.tokenizeForSentence(text);
         _tokensCacheMap[text] = tokens;
-        const filterByType = tokens.filter(token => {
+        const filterByType = tokens.filter((token, index) => {
+            const nextToken = tokens[index + 1];
+            // token[特殊・ダ] + nextToken[アル] なら 常体(である調) として認識する
             const conjugatedType = token["conjugated_type"];
             if (conjugatedType === Types.dearu) {
-                if (token["conjugated_form"] === "連用形" || token["conjugated_form"] === "連用タ接続") {
-                    return true;
+                if (token["pos"] === "助動詞" && token["conjugated_form"] === "連用形") {
+                    if (nextToken && nextToken["conjugated_type"] === "五段・ラ行アル") {
+                        return true;
+                    }
                 }
             } else if (conjugatedType === Types.desu) {
                 // TODO: can omit?

--- a/test/analyze-test.js
+++ b/test/analyze-test.js
@@ -37,12 +37,24 @@ describe("analyze-test", function () {
         });
     });
     describe("analyzeDearu", function () {
-        it("should not match である", function () {
-            // "な" は マッチしない
-            // "conjugated_type": "特殊・ダ",
-            // "conjugated_form": "体言接続",
-            return analyzeDearu("これを使い簡単なものを作る").then(results => {
-                assert(results.length === 0);
+        context("when no match", function () {
+            it("このパターンだけ**では**難しい", function () {
+                return analyzeDearu("このパターンだけでは難しい").then(results => {
+                    assert(results.length === 0);
+                });
+            });
+            it("ではなく", function () {
+                return analyzeDearu("動的にメソッドを追加するだけではなく、既存の実装を上書きする。").then(results => {
+                    assert(results.length === 0);
+                });
+            });
+            it("簡単**な***ものを作る", function () {
+                // "な" は マッチしない
+                // "conjugated_type": "特殊・ダ",
+                // "conjugated_form": "体言接続",
+                return analyzeDearu("これを使い簡単なものを作る").then(results => {
+                    assert(results.length === 0);
+                });
             });
         });
         it("should found である 後ろに明示的なストッパーがない場合", function () {


### PR DESCRIPTION
"ではなく" というような表現は常体(である調)として認識しない

fix https://github.com/azu/textlint-rule-no-mix-dearu-desumasu/issues/10